### PR TITLE
Added new cli tool to setup.sh

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -26,6 +26,6 @@ You should see **Switched to context "cluster.local-context"** when done.
 bash setup.sh
 ```
 
-This setup script will install the IBM Cloud Private plugin for the command line and configure it to point to the cluster within ICP. This also properly configures helm to work with ICP.
+This setup script will authenticate the 'cloudctl' tool with your instance of ICP and configure it to point to the cluster within ICP. This also properly configures helm to work with ICP.
 
 ![Helm Configured](../images/helmConfigured.png)

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-#Install latest ICP plugin
-bx plugin install ./icp-linux-amd64 -f
-
-#Log into the ICP plugin
-bx pr login -u admin -p admin -c id-mycluster-account
+#log into the cloudctl tool for managing ICP
+cloudctl login -u admin -p admin -c id-mycluster-account -a https://mycluster.icp:8443 -n default --skip-ssl-validation
 
 #Initialize helm
 helm init


### PR DESCRIPTION
In ICP 3.2, the cli tool to interact with ICP has changed from a plugin of the old bx tool to a new tool altogther called 'cloudctl'. This change replaced bx with cloudctl in the setup script.

Signed-off-by: Oliver Rodriguez <odrodrig@us.ibm.com>